### PR TITLE
Add conditionType to EVM contract conditions

### DIFF
--- a/src/evmcc.ts
+++ b/src/evmcc.ts
@@ -3,6 +3,7 @@ import { publicationAbi, safeAbi } from "./abi.js";
 
 export const evmContractConditions = (safeAddress: string, publicationAddress: string) => [
     {
+        conditionType: "evmContract",
         contractAddress: publicationAddress,
         functionName: "canPublish",
         functionParams: [ safeAddress ],
@@ -16,6 +17,7 @@ export const evmContractConditions = (safeAddress: string, publicationAddress: s
     },
     { operator: "and" },
     {
+        conditionType: "evmContract",
         contractAddress: safeAddress,
         functionName: "isOwner",
         functionParams: [":userAddress"],


### PR DESCRIPTION
apologies for the confusion here - `decryptAndCombine()` takes "unified contract conditions", docs are here: https://developer.litprotocol.com/sdk/access-control/condition-types/unified-access-control-conditions

Adding `conditionType: "evmContract",` should fix your issue and tell the nodes that the access control conditions you're passing are EVM Contract Conditions